### PR TITLE
Fix usage command

### DIFF
--- a/README
+++ b/README
@@ -13,4 +13,4 @@ The only dependency of teenygrad is numpy (well, and tqdm)
 
 Usage:
 pip install numpy tqdm
-PYTHONPATH="." python mnist.py
+PYTHONPATH="." python -m mnist


### PR DESCRIPTION
Current version causes an error due to __file__ not pointing to the current file path.  This is because __file__ is only active if the file is loaded as a module.